### PR TITLE
Tokenizing blocked content class name

### DIFF
--- a/assets/js/clicks.js
+++ b/assets/js/clicks.js
@@ -1,0 +1,7 @@
+export function handleRightClicks() {
+	let noContext = document.querySelector('.swg--paywall-prompt')
+
+	noContext.addEventListener('contextmenu', e => {
+		e.preventDefault();
+	});
+}

--- a/assets/js/clicks.js
+++ b/assets/js/clicks.js
@@ -1,7 +1,9 @@
 export function handleRightClicks() {
 	let noContext = document.querySelector('.swg--paywall-prompt')
 
-	noContext.addEventListener('contextmenu', e => {
-		e.preventDefault();
-	});
+	if (noContext) {
+		noContext.addEventListener('contextmenu', e => {
+			e.preventDefault();
+		});
+	}
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,5 @@
 import { handleSignInClicks, handleSubscribeClicks, handleContributeClicks } from "./buttons";
+import { handleRightClicks } from "./clicks";
 import { handlePaymentResponse } from "./payments";
 import { unlockPageMaybe } from "./unlock";
 
@@ -12,6 +13,7 @@ import { unlockPageMaybe } from "./unlock";
   handleSignInClicks();
   handleSubscribeClicks(swg);
   handleContributeClicks(swg);
+  handleRightClicks();
 
   // Unlock page if possible.
   return unlockPageMaybe(swg);

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,10 +2,6 @@
 	opacity: 0.5;
 }
 
-body:not(.swg--is-amp) article:not(.swg--page-is-unlocked) .swg--locked-content {
-	display: none;
-}
-
 body:not(.swg--is-amp) article:not(.swg--page-is-locked) .swg--paywall-prompt {
 	display: none;
 }

--- a/includes/Filters.php
+++ b/includes/Filters.php
@@ -63,6 +63,7 @@ final class Filters {
 
 		$more_tag         = '<span id="more-' . get_the_ID() . '"></span>';
 		$content_segments = explode( $more_tag, $content );
+		$documentID       = 'g' . hash( 'md5', get_post( get_the_ID() )->post_name );
 
 		// Add Paywall wrapper & prompt.
 		if ( count( $content_segments ) > 1 ) {
@@ -79,7 +80,7 @@ final class Filters {
 	</button>
 </p>
 
-<div class="swg--locked-content" subscriptions-section="content">
+<div id="' . $documentID . '" class="swg--locked-content" subscriptions-section="content">
 ' . $content_segments[1] . '
 </div>
 ';

--- a/includes/Header.php
+++ b/includes/Header.php
@@ -59,6 +59,11 @@ final class Header {
 
 			// Make WP URLs available to SwgPress' JavaScript.
 			$api_base_url = get_option( 'siteurl' ) . '/wp-json/subscribewithgoogle/v1';
+
+			$documentID = 'false';
+			if ( is_single() ) {
+				$documentID = 'g' . hash( 'md5', get_post( get_the_ID() )->post_name );
+			}
 			wp_localize_script(
 				'subscribe-with-google',
 				'SubscribeWithGoogleWpGlobals',
@@ -129,6 +134,12 @@ final class Header {
 			}
 		}
 		</script>
+
+		<style>
+			#<?php echo $documentID; ?> {
+				display: none;
+			}
+		</style>
 		<?php
 	}
 }


### PR DESCRIPTION
Instead of using a fixed name for the CSS class that will hide the protected content, this method creates a string unique to the URL of the post (cacheable) and appends the `{display: none}` rule to it inline.

I've also disabled using the context menu on the SwG Paywall Prompt.