### PR TITLE
Enable a server-side paywall

### DIFF
--- a/assets/js/unlock.js
+++ b/assets/js/unlock.js
@@ -1,4 +1,5 @@
 import { $, $$ } from "./utils/dom";
+import { handleErrors } from "./utils/fetch";
 import { experimentIsOn } from "./experiments";
 
 
@@ -20,12 +21,25 @@ export async function unlockPageMaybe(swg) {
     return;
   }
 
-  const entitled = await userIsEntitledToProduct(product, swg);
-  if (entitled) {
-    $article.classList.add('swg--page-is-unlocked');
-  } else {
-    $article.classList.add('swg--page-is-locked');
-  }
+  getFullPostIfUserIsEntitled();
+
+}
+
+/**
+ * Fetches the full HTML content of the unlocked page and replaces the current content with it
+ * 
+ */
+async function getFullPostIfUserIsEntitled() {
+  let articleHtmlUrl = '/wp-json/wp/v2/posts/' + SubscribeWithGoogleWpGlobals.POST_ID;
+
+  fetch(articleHtmlUrl)
+    .then(handleErrors)
+    .then(response => response.json())
+    .then((data) => {
+      let contentHtml = data;
+      console.log($('.entry-content'));
+      $('.entry-content').innerHTML = contentHtml;
+    });
 }
 
 /**

--- a/assets/js/unlock.js
+++ b/assets/js/unlock.js
@@ -21,7 +21,8 @@ export async function unlockPageMaybe(swg) {
     return;
   }
 
-  getFullPostIfUserIsEntitled();
+  $article.classList.add('swg--page-is-locked');
+  getFullPostIfUserIsEntitled($article);
 
 }
 
@@ -29,7 +30,7 @@ export async function unlockPageMaybe(swg) {
  * Fetches the full HTML content of the unlocked page and replaces the current content with it
  * 
  */
-async function getFullPostIfUserIsEntitled() {
+async function getFullPostIfUserIsEntitled($article) {
   let articleHtmlUrl = '/wp-json/wp/v2/posts/' + SubscribeWithGoogleWpGlobals.POST_ID;
 
   fetch(articleHtmlUrl)
@@ -37,9 +38,12 @@ async function getFullPostIfUserIsEntitled() {
     .then(response => response.json())
     .then((data) => {
       let contentHtml = data;
-      console.log($('.entry-content'));
       $('.entry-content').innerHTML = contentHtml;
-    });
+      $article.classList.add('swg--entitlements-have-loaded')
+    })
+    .catch((err) => {
+      $article.classList.add('swg--entitlements-have-loaded')
+    })
 }
 
 /**

--- a/assets/js/utils/fetch.js
+++ b/assets/js/utils/fetch.js
@@ -1,0 +1,6 @@
+export function handleErrors(response) {
+	if (!response.ok) {
+		throw Error(response.statusText);
+	}
+	return response;
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -6,6 +6,10 @@ body:not(.swg--is-amp) article:not(.swg--page-is-unlocked) .swg--locked-content 
 	display: none;
 }
 
+body:not(.swg--is-amp) article.swg--entitlements-have-loaded .swg--paywall-checking-entitlements {
+	display: none;
+}
+
 body:not(.swg--is-amp) article:not(.swg--page-is-locked) .swg--paywall-prompt {
 	display: none;
 }

--- a/includes/Filters.php
+++ b/includes/Filters.php
@@ -67,6 +67,9 @@ final class Filters {
 		// Add Paywall wrapper & prompt.
 		if ( count( $content_segments ) > 1 ) {
 			$content_segments[1] = '
+<p class="swg--paywall-checking-entitlements">
+			Checking for entitlements...
+</p>
 <p class="swg--paywall-prompt" subscriptions-section="content-not-granted">
 	🔒 <span>Subscribe to unlock the rest of this article.</span>
 	<br />

--- a/includes/Filters.php
+++ b/includes/Filters.php
@@ -82,9 +82,6 @@ final class Filters {
 	</button>
 </p>
 
-<div class="swg--locked-content" subscriptions-section="content">
-' . $content_segments[1] . '
-</div>
 ';
 		}
 

--- a/includes/Header.php
+++ b/includes/Header.php
@@ -48,21 +48,26 @@ final class Header {
 				true
 			);
 
-			// JavaScript for SwgPress.
-			wp_enqueue_script(
-				'subscribe-with-google',
-				plugins_url( '../dist/assets/js/main.js', __FILE__ ),
-				null,
-				1,
-				true
-			);
+			if (is_single()) {
+				// JavaScript for SwgPress.
+				wp_enqueue_script(
+					'subscribe-with-google',
+					plugins_url('../dist/assets/js/main.js', __FILE__),
+					null,
+					1,
+					true
+				);
+			}
 
 			// Make WP URLs available to SwgPress' JavaScript.
 			$api_base_url = get_option( 'siteurl' ) . '/wp-json/subscribewithgoogle/v1';
 			wp_localize_script(
 				'subscribe-with-google',
 				'SubscribeWithGoogleWpGlobals',
-				array( 'API_BASE_URL' => $api_base_url )
+				array(
+					'API_BASE_URL' => $api_base_url,
+					'POST_ID' => get_the_ID()
+				)
 			);
 		} else {
 			// Add SwG's AMP extension.

--- a/includes/Header.php
+++ b/includes/Header.php
@@ -48,11 +48,11 @@ final class Header {
 				true
 			);
 
-			if (is_single()) {
+			if ( is_single() ) {
 				// JavaScript for SwgPress.
 				wp_enqueue_script(
 					'subscribe-with-google',
-					plugins_url('../dist/assets/js/main.js', __FILE__),
+					plugins_url( '../dist/assets/js/main.js', __FILE__ ),
 					null,
 					1,
 					true
@@ -66,7 +66,7 @@ final class Header {
 				'SubscribeWithGoogleWpGlobals',
 				array(
 					'API_BASE_URL' => $api_base_url,
-					'POST_ID' => get_the_ID()
+					'POST_ID'      => get_the_ID(),
 				)
 			);
 		} else {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -28,6 +28,7 @@ final class Plugin {
 		new Header();
 		new ManagePosts();
 		new Shortcodes();
+		new PostRestAPI();
 	}
 
 	/** Loads the plugin main instance and initializes it. */

--- a/includes/PostRestAPI.php
+++ b/includes/PostRestAPI.php
@@ -19,6 +19,18 @@ use WP_Error;
 final class PostRestAPI {
 
 
+
+	/**
+	 * Identifier of GoogleSignIn class.
+	 * Tests can override this.
+	 *
+	 * @var string
+	 */
+	public static $google_sign_in_class =
+	'SubscribeWithGoogle\WordPress\GoogleSignIn';
+
+	protected static $gsi_client;
+
 	/** Adds action handlers. */
 	public function __construct() {
 		 add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
@@ -43,11 +55,13 @@ final class PostRestAPI {
 	 */
 	public static function get_post( $request ) {
 
+		self::$gsi_client = new self::$google_sign_in_class();
+
 		$post_ID = $request['id'];
 		$query   = get_post( $post_ID );
 		$content = apply_filters( 'the_content', $query->post_content );
 
-		$entitled_products_for_user = self::get_entitled_products_for_entitlements( GoogleSignIn::get_entitlements() );
+		$entitled_products_for_user = self::get_entitled_products_for_entitlements( self::$gsi_client::get_entitlements() );
 
 		$product_key = Plugin::key( 'product' );
 		$product     = get_post_meta( $post_ID, $product_key, true );

--- a/includes/PostRestAPI.php
+++ b/includes/PostRestAPI.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Class SubscribeWithGoogle\WordPress\PostRestAPI
+ *
+ * @package   SubscribeWithGoogle\WordPress
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ */
+
+namespace SubscribeWithGoogle\WordPress;
+
+use WP_REST_Request;
+use WP_Error;
+
+/**
+ * Override the REST API route that leads directly to the WP Post Content
+ */
+final class PostRestAPI {
+
+
+	/** Adds action handlers. */
+	public function __construct() {
+		 add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+	}
+
+	/** Registers custom REST routes. */
+	public static function register_rest_routes() {
+		register_rest_route(
+			'wp/v2',
+			'/posts/(?P<id>\d+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( __CLASS__, 'get_post' ),
+			)
+		);
+	}
+
+	/**
+	 * Check with the Get Entitlement API to see if this user has content before delivering it to them
+	 *
+	 * @param WP_REST_Request $request with `post ID`.
+	 */
+	public static function get_post( $request ) {
+
+		$post_ID = $request['id'];
+		$query   = get_post( $post_ID );
+		$content = apply_filters( 'the_content', $query->post_content );
+
+		$entitled_products_for_user = self::get_entitled_products_for_entitlements( GoogleSignIn::get_entitlements() );
+
+		$product_key = Plugin::key( 'product' );
+		$product     = get_post_meta( $post_ID, $product_key, true );
+
+		$free_key = Plugin::key( 'free' );
+		$free     = get_post_meta( $post_ID, $free_key, true );
+		$query    = get_post( $post_ID );
+		$content  = apply_filters( 'the_content', $query->post_content );
+
+		if ( $free ) {
+			return $content;
+		}
+
+		$publication_id      = get_option( Plugin::key( 'publication_id' ) );
+		$product_id_for_post = $publication_id . ':' . $product;
+
+		if ( in_array( $product_id_for_post, $entitled_products_for_user ) ) {
+			return $content;
+		}
+
+		return new WP_Error( 'missing_entitlements', __( 'You are not entitled to this content' ), array( 'status' => 401 ) );
+	}
+
+	protected static function get_entitled_products_for_entitlements( $entitlements ) {
+		$products = array();
+		if ( isset( $entitlements->entitlements ) ) {
+			foreach ( $entitlements->entitlements as $ent ) {
+				$products = array_merge( $ent->products );
+			}
+		}
+
+		return $products;
+	}
+}

--- a/includes/Rest.php
+++ b/includes/Rest.php
@@ -42,10 +42,5 @@ final class Rest {
 		if ( $request_url['host'] !== $site_url['host'] ) {
 			throw new Exception( 'Request host was not valid.' );
 		}
-
-		// Verify path.
-		if ( strpos( $request_url['path'], $site_url['path'] ) !== 0 ) {
-			throw new Exception( 'Request path did not belong to WP site.' );
-		}
 	}
 }

--- a/tests/phpunit/integration/GoogleSignInMock.php
+++ b/tests/phpunit/integration/GoogleSignInMock.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SubscribeWithGoogle\WordPress\Tests;
+
+
+/** Mock of the GoogleSignIn class. */
+class GoogleSignInMock
+{
+
+	public static $entitlements = [];
+
+	public static function reset()
+	{
+		self::$entitlements = [];
+	}
+
+	public static function get_entitlements()
+	{
+		return self::$entitlements;
+	}
+}

--- a/tests/phpunit/integration/PostContentTest.php
+++ b/tests/phpunit/integration/PostContentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SubscribeWithGoogle\WordPress\Tests;
+
+
+use SubscribeWithGoogle\WordPress\Filters;
+use WP_UnitTestCase;
+
+class PostContentTest extends WP_UnitTestCase
+{
+
+	private $post_id = null;
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		if ($this->post_id == null) {
+			// Set publication ID site-wide.
+			update_option('SubscribeWithGoogle_publication_id', 'example.com');
+
+			// Create a post.
+			$this->post_id = $this->factory->post->create();
+
+			wp_update_post([
+				'ID' => $this->post_id,
+				'post_content' => '<h1>Hello world</h1> <span id="more-' . $this->post_id . '"></span> <p>Premium Only.</p>'
+			]);
+		}
+	}
+
+
+	public function test__does_not_include_hidden_content_if_post_is_not_free()
+	{
+		update_post_meta(
+			$this->post_id,
+			'SubscribeWithGoogle_product',
+			'premium'
+		);
+		$this->go_to("/?p=" . $this->post_id);
+		$content = Filters::the_content(get_post($this->post_id)->post_content);
+
+		$this->assertNotRegexp('/\bPremium Only\b/', $content);
+	}
+
+	public function test__does_include_hidden_content_if_post_is_free()
+	{
+		update_post_meta(
+			$this->post_id,
+			'SubscribeWithGoogle_free',
+			'true'
+		);
+		$this->go_to("/?p=" . $this->post_id);
+		$content = Filters::the_content(get_post($this->post_id)->post_content);
+
+		$this->assertRegexp('/\bPremium Only\b/', $content);
+	}
+}

--- a/tests/phpunit/integration/PostRestAPITest.php
+++ b/tests/phpunit/integration/PostRestAPITest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SubscribeWithGoogle\WordPress\Tests;
+
+use WP_UnitTestCase;
+use SubscribeWithGoogle\WordPress\GoogleSignIn;
+use SubscribeWithGoogle\WordPress\PostRestAPI;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class PostRestAPITest extends WP_UnitTestCase
+{
+
+	public $post_id;
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		// Start REST server.
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server;
+		do_action('rest_api_init');
+
+		// Mock the Google Client.
+		GoogleClientMock::reset();
+		GoogleSignIn::$google_client_class = 'SubscribeWithGoogle\WordPress\Tests\GoogleClientMock';
+
+		// Always set a refresh token
+		$_COOKIE['swg_refresh_token'] = 'refresh_token';
+		GoogleClientMock::$access_token_response = array(
+			'access_token' => 'access_token',
+		);
+
+		// Mock the Google Sign In class
+		GoogleSignInMock::reset();
+		PostRestAPI::$google_sign_in_class =
+			'SubscribeWithGoogle\WordPress\Tests\GoogleSignInMock';
+
+		// Set site URL.
+		update_option('siteurl', 'https://do.ma.in/pa/th');
+
+		// Define publication ID.
+		update_option('SubscribeWithGoogle_publication_id', 'example.com');
+
+		// Set referer.
+		$_SERVER['HTTP_REFERER'] = 'https://do.ma.in/pa/th/y';
+
+		// Create a post.
+		$this->post_id = $this->factory->post->create();
+		wp_update_post(array(
+			'ID' => $this->post_id,
+			'post_content' => '<h1>Hello world!</h1>',
+			'post_name' => 'paid-post',
+			'post_title' => 'Paid post',
+		));
+
+		// Make it premium
+		update_post_meta($this->post_id, 'SubscribeWithGoogle_product', 'premium');
+	}
+
+	public function tearDown()
+	{
+		$_COOKIE = [];
+		parent::tearDown();
+	}
+
+	public function test__prevent_fetching_of_content_if_the_user_is_missing_entitlements()
+	{
+		// Set our mock entitlements
+		GoogleSignInMock::$entitlements = [];
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/wp/v2/posts/' . $this->post_id
+		);
+
+		$response = $this->server->dispatch($request);
+
+		$this->assertEquals(
+			401,
+			$response->data['data']['status']
+		);
+	}
+
+	public function test__allow_fetching_of_content_if_the_user_has_proper_entitlements()
+	{
+		// Set our mock entitlements
+		$entitlementsJson = '{"entitlements" : [ {"products" : ["example.com:premium"]} ]}';
+		GoogleSignInMock::$entitlements = json_decode($entitlementsJson);
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/wp/v2/posts/' . $this->post_id
+		);
+
+		$response = $this->server->dispatch($request);
+		$this->assertEquals(
+			'<h1>Hello world!</h1>',
+			trim($response->data)
+		);
+	}
+
+	public function test__prevents_fetching_of_content_if_the_user_has_improper_entitlements()
+	{
+		// Set our mock entitlements
+		$entitlementsJson = '{"entitlements" : [ {"products" : ["example.com:basic"]} ]}';
+		GoogleSignInMock::$entitlements = json_decode($entitlementsJson);
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/wp/v2/posts/' . $this->post_id
+		);
+
+		$response = $this->server->dispatch($request);
+		$this->assertEquals(
+			401,
+			$response->data['data']['status']
+		);
+	}
+}

--- a/tests/phpunit/integration/RestTest.php
+++ b/tests/phpunit/integration/RestTest.php
@@ -40,12 +40,4 @@ class RestTest extends PHPUnit_Framework_TestCase
 		$this->expectExceptionMessage('Request host was not valid');
 		Rest::verify_request_origin();
 	}
-
-	public function test__verify_request_origin__invalid_path__throws()
-	{
-		$_SERVER['HTTP_REFERER'] = 'https://do.ma.in/p4/th';
-
-		$this->expectExceptionMessage('Request path did not belong to WP site');
-		Rest::verify_request_origin();
-	}
 }


### PR DESCRIPTION
Move the paywall to the client-side by using fetch() and a SwG API call.

Includes test coverage, and all test are at green 🍀

This did require removing the `path` validation because the WP Rest API is guaranteed to be a different path than the referrer. If this is unacceptable, we'll figure out something.